### PR TITLE
Switch CI from Maven to Gradle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,19 +18,11 @@ jobs:
               with:
                 distribution: temurin
                 java-version: 17
-                cache: maven
+                cache: gradle
+                
+            - name: build
+              uses: ./gradlew build
 
-            - name: clean
-              run: mvn clean
-
-            - name: install dependencies
-              run: mvn install
-
-            - name: test
-              run: mvn test
-
-            - name: clean build
-              run: mvn package
               
             - name: Upload build artifacts
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
Updated CI workflow to use Gradle instead of Maven for building and removed Maven commands.